### PR TITLE
Fix: Change port 3000 into 8080

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const session = require('express-session');
 const FileStore = require('session-file-store')(session);
 const app = express();
-const port = 3000;
+const port = 8080;
 const fileStoreOptions = {};
 
 const mainRouter = require('./routes/main');


### PR DESCRIPTION
# Summary

Since the aws server uses port 8080 by default, it is changed from 3000 to 8080.